### PR TITLE
Fix demo failures by using separate images

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ helm repo update
 helm install kyverno kyverno/kyverno -n next-demo --create-namespace
 ```
 
+## Pre-demo reset steps
+
+Restart podman containers that are stopped:
+
+```bash
+podman start sigstore-demo-control-plane
+podman start sigstore-demo-worker
+```
+
+Log in to ghcr.io:
+
+```bash
+podman login ghcr.io
+```
+
 ## Configure policy
 
 
@@ -46,7 +61,7 @@ kubectl run good-image --image=ghcr.io/lukehinds/redhat-next-security-demo:main
 kubectl delete pod good-image --now
 ```
 
-Add lhinds@redhat.com to policy, and apply config 
+Add lhinds@redhat.com to policy, and apply config
 
 ```yaml
 - keyless:
@@ -70,7 +85,7 @@ kubectl run good-image --image=ghcr.io/lukehinds/redhat-next-security-demo:main
 cosign sign ghcr.io/lukehinds/redhat-next-security-demo:main
 ```
 
-Look up signature and cert in rekor and set 
+Look up signature and cert in rekor and set
 
 ```bash
 logindex=12345
@@ -91,4 +106,3 @@ Run good image, runs
 ```bash
 kubectl run good-image --image=ghcr.io/lukehinds/redhat-next-security-demo:main
 ```
-

--- a/manifests/imagePolicy-email.yaml
+++ b/manifests/imagePolicy-email.yaml
@@ -7,7 +7,7 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    policies.kyverno.io/minversion: 1.4.2   
+    policies.kyverno.io/minversion: 1.4.2
 spec:
   validationFailureAction: enforce
   background: false
@@ -22,11 +22,8 @@ spec:
       - imageReferences:
         - "*"
         attestors:
-        - count: 2
+        - count: 1
           entries:
           - keyless:
-              issuer: "https://token.actions.githubusercontent.com"
-              subject: "https://github.com/lukehinds/redhat-next-security-demo/.github/workflows/*"
-          - keyless:
-              issuer: https://accounts.google.com
               subject: "*@redhat.com"
+              issuer: "https://accounts.google.com"

--- a/manifests/imagePolicy.yaml
+++ b/manifests/imagePolicy.yaml
@@ -7,7 +7,7 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    policies.kyverno.io/minversion: 1.4.2   
+    policies.kyverno.io/minversion: 1.4.2
 spec:
   validationFailureAction: enforce
   background: false


### PR DESCRIPTION
Note that where I mention needing to use an "unsigned container", you can simply take the existing container template and remove the `cosign sign` step in the `build-sign-upload` workflow. Then you'll end up with a container uploaded to ghcr.io you can sign with cosign locally to do the email potion of the demo.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>
